### PR TITLE
Add support for Dogstatsd (Datadog) metric tags.

### DIFF
--- a/lib/statsd.lua
+++ b/lib/statsd.lua
@@ -1,8 +1,8 @@
 local Statsd = {}
 
-Statsd.time  = function (bucket, time) Statsd.register(bucket, time .. "|ms") end
-Statsd.count = function (bucket, n)    Statsd.register(bucket, n .. "|c") end
-Statsd.incr  = function (bucket)       Statsd.count(bucket, 1) end
+Statsd.time  = function (bucket, time, tags) Statsd.register(bucket, time .. "|ms", tags) end
+Statsd.count = function (bucket, n, tags)    Statsd.register(bucket, n .. "|c", tags) end
+Statsd.incr  = function (bucket, tags)       Statsd.count(bucket, 1, tags) end
 
 Statsd.buffer = {} -- this table will be shared per worker process
                    -- if lua_code_cache is off, it will be cleared every request
@@ -16,13 +16,22 @@ Statsd.flush = function(sock, host, port)
                udp:close()
             end)
    end
-   
+
    -- empty buffer
    for k in pairs(Statsd.buffer) do Statsd.buffer[k] = nil end
 end
 
-Statsd.register = function (bucket, suffix, sample_rate)
-   table.insert(Statsd.buffer, bucket .. ":" .. suffix .. "\n")
+Statsd.register = function (bucket, suffix, tags)
+   local metric_part = bucket .. ":" .. suffix
+   if tags then
+               local tag_parts = {}
+               for k, v in pairs(tags) do
+                  table.insert(tag_parts, k .. ":" .. v)
+               end
+               table.insert(Statsd.buffer, metric_part .. "|#" .. table.concat(tag_parts, ",") .. "\n")
+   else
+               table.insert(Statsd.buffer, metric_part .. "\n")
+   end
 end
 
-return Statsd 
+return Statsd


### PR DESCRIPTION
Adds an optional argument to methods used to record metrics that sets tags. These are read by Dogstatsd and used by Datadog to allow filtering and grouping metrics more easily than only using the metric name.

If the tags argument is omitted data will be written to the Statsd client in the same format as previously so this change should be backwards compatible.